### PR TITLE
Visualize datasplit configs

### DIFF
--- a/dashboard/dacapo/helpers.py
+++ b/dashboard/dacapo/helpers.py
@@ -2,12 +2,20 @@ import attr
 from dashboard.stores import get_stores
 
 import dacapo
+from dacapo.experiments.datasplits import DataSplit
 from dacapo.store.conversion_hooks import cls_fun
 from .configurables import parse_field, parse_fields
 
 import importlib
 import pkgutil
 
+
+def datasplit_visualization_link(datasplit: str):
+    config_store = get_stores().config
+    datasplit_config = config_store.retrieve_datasplit_config(datasplit)
+    datasplit = datasplit_config.datasplit_type(datasplit_config)
+    link = datasplit._neuroglancer_link()
+    return link
 
 def get_checklist_data():
 

--- a/dashboard/dacapo/helpers.py
+++ b/dashboard/dacapo/helpers.py
@@ -2,12 +2,20 @@ import attr
 from dashboard.stores import get_stores
 
 import dacapo
+from dacapo.experiments import Run
 from dacapo.experiments.datasplits import DataSplit
 from dacapo.store.conversion_hooks import cls_fun
 from .configurables import parse_field, parse_fields
 
 import importlib
 import pkgutil
+
+
+def training_visualization_link(run_config):
+    array_store = get_stores().array
+    run = Run(run_config)
+    link = array_store._visualize_training(run)
+    return link
 
 
 def datasplit_visualization_link(datasplit: str):

--- a/dashboard/dacapo/monitor.py
+++ b/dashboard/dacapo/monitor.py
@@ -32,7 +32,12 @@ def get_runs():
         request_data = request.json
 
         config_store = get_stores().config
-        run_config_names = config_store.retrieve_run_config_names()
+        run_config_names = config_store.retrieve_run_config_names(
+            task_names=request_data["tasks"],
+            datasplit_names=request_data["datasplits"],
+            architecture_names=request_data["architectures"],
+            trainer_names=request_data["trainers"],
+        )
         run_configs = [
             config_store.retrieve_run_config(run_name) for run_name in run_config_names
         ]
@@ -48,12 +53,6 @@ def get_runs():
                 ),
             }
             for run_name, run_config in zip(run_config_names, run_configs)
-            if (
-                run_config.task_config.name in request_data["tasks"]
-                and run_config.datasplit_config.name in request_data["datasplits"]
-                and run_config.architecture_config.name in request_data["architectures"]
-                and run_config.trainer_config.name in request_data["trainers"]
-            )
         ]
         return jsonify(runs)
 

--- a/dashboard/dacapo/monitor.py
+++ b/dashboard/dacapo/monitor.py
@@ -3,7 +3,7 @@ from dacapo.experiments import RunConfig
 
 from dashboard.stores import get_stores
 from .blue_print import bp
-from .helpers import get_checklist_data, get_evaluator_score_names
+from .helpers import get_checklist_data, get_evaluator_score_names, datasplit_visualization_link, training_visualization_link
 from dacapo import train
 
 import itertools
@@ -27,6 +27,12 @@ def plot():
 def get_runs():
     if request.method == "GET":
         context = get_checklist_data()
+        datasplits = context.pop("datasplits")
+        datasplits = [
+            (datasplit, datasplit_visualization_link(datasplit))
+            for datasplit in datasplits[:8]
+        ]
+        context["datasplits"] = datasplits
         return render_template("dacapo/runs.html", **context)
     if request.method == "POST":
         request_data = request.json
@@ -51,6 +57,7 @@ def get_runs():
                 "evaluator_score_names": get_evaluator_score_names(
                     run_config.task_config.name
                 ),
+                "neuroglancer_link": training_visualization_link(run_config),
             }
             for run_name, run_config in zip(run_config_names, run_configs)
         ]

--- a/dashboard/stores.py
+++ b/dashboard/stores.py
@@ -1,7 +1,11 @@
 from flask import g
 
 from dacapo.store import (
-    create_config_store, create_stats_store, create_weights_store)
+    create_config_store,
+    create_stats_store,
+    create_weights_store,
+    create_array_store,
+)
 
 from collections import namedtuple
 
@@ -29,7 +33,10 @@ def init_app(app):
 
 
 def get_stores_as_named_tuple():
-    Stores = namedtuple('stores', ['config', 'stats', 'weights'])
-    return Stores(create_config_store(),
-                  create_stats_store(),
-                  create_weights_store())
+    Stores = namedtuple("stores", ["config", "stats", "weights", "array"])
+    return Stores(
+        create_config_store(),
+        create_stats_store(),
+        create_weights_store(),
+        create_array_store(),
+    )

--- a/dashboard/templates/dacapo/common.html
+++ b/dashboard/templates/dacapo/common.html
@@ -23,8 +23,8 @@
         </div>
         <div class="scroll_checklist">
             {% for datasplit in datasplits %}
-            <input type="checkbox" id="{{datasplit}}" /><span title="{{datasplit}}" onclick="copyJsonData(this.title)">
-                {{datasplit}}
+            <input type="checkbox" id="{{datasplit.0}}" /><span title="{{datasplit.0}}" onclick="copyJsonData(this.title)">
+                <a href="{{datasplit.1}}">{{datasplit.0}}</a>
             </span><br />
             {% endfor %}
         </div>

--- a/dashboard/templates/dacapo/results.html
+++ b/dashboard/templates/dacapo/results.html
@@ -25,7 +25,7 @@
             {% for run in runs %}
             <tr>
                 <td></td>
-                <td>{{run.name}}</td>
+                <td><a href="{{run.neuroglancer_link}}">{{run.name}}</a></td>
                 <td>{{run.repetition}}</td>
                 <td>{{run.trained_iterations}}</td>
                 <td>{{run.started}}</td>

--- a/dashboard/templates/dacapo/runs.html
+++ b/dashboard/templates/dacapo/runs.html
@@ -25,7 +25,7 @@
             {% for run in runs %}
             <tr>
                 <td></td>
-                <td>{{run.name}}</td>
+                <td><a href="{{run.neuroglancer_link}}">{{run.name}}</a></td>
                 <td>{{run.task_config_name}}</td>
                 <td>{{run.datasplit_config_name}}</td>
                 <td>{{run.architecture_config_name}}</td>
@@ -33,15 +33,14 @@
                 <td>
                     <select name="temp" id="temp">
                         {% for evaluator_score_name in run.evaluator_score_names %}
-                        <option value={{evaluator_score_name}}>{{evaluator_score_name}}</option> {{evaluator_score_name}}
+                        <option value={{evaluator_score_name}}>{{evaluator_score_name}}</option>
+                        {{evaluator_score_name}}
                         {% endfor %}
                     </select>
                 </td>
-                <td><input type="checkbox"
-                        id="{{run.name}}_higherIsBetter">
+                <td><input type="checkbox" id="{{run.name}}_higherIsBetter">
                 </td>
-                <td><input type="checkbox"
-                        id="{{run.name}}_plotLoss">
+                <td><input type="checkbox" id="{{run.name}}_plotLoss">
                 </td>
             </tr>
             {% endfor %}
@@ -58,9 +57,19 @@
     let table = $("#new-runs-table").DataTable({
         columnDefs: [
             {
-            orderable: false,
-            className: 'select-checkbox',
-            targets: 0
+                orderable: false,
+                className: 'select-checkbox',
+                targets: 0
+            },
+            {
+                render: function (data, t, row) {
+                    console.log("<a href="+row[9]+">")
+                    var $link = $("<a href='"+row[9]+"'>" + row[1] + "</a>");
+                    console.log($link.prop("outerHTML"))
+                    return $link.prop("outerHTML");
+                },
+                targets: 1,
+                className: 'dt-body-center'
             },
             {
                 render: function (data, t, row) {
@@ -87,7 +96,8 @@
                     return $checkbox.prop("outerHTML");
                 },
                 targets: 7,
-                className: 'dt-body-center'
+                className: 'dt-body-center',
+                visible: false
             },
             {
                 render: function (data, t, row) {
@@ -129,7 +139,7 @@
             run = item[1]
             plotInfo.runs.push(run)
             plotInfo.scoreNames.push(document.getElementById(run + "_score").value)
-            plotInfo.higherIsBetters.push(document.getElementById(run + "_higherIsBetter").checked)
+            // plotInfo.higherIsBetters.push(document.getElementById(run + "_higherIsBetter").checked)
             plotInfo.plotLosses.push(document.getElementById(run + "_plotLoss").checked)
         });
 
@@ -176,12 +186,12 @@
                 fetch("{{ url_for('dacapo.get_runs') }}", { method: "POST", headers: { "Content-Type": 'application/json', "Accept": "application/json" }, body: JSON.stringify(array_data) }).then(response => response.json()).then(ids => {
                     let rows = [];
                     ids.forEach((run) => {
-                        rows.push(["", run.name, run.task_config_name, run.datasplit_config_name, run.architecture_config_name, run.trainer_config_name, run.evaluator_score_names, "", ""]);
+                        rows.push(["", run.name, run.task_config_name, run.datasplit_config_name, run.architecture_config_name, run.trainer_config_name, run.evaluator_score_names, "", "", run.neuroglancer_link]);
                     })
                     table.rows.add(rows).draw();
                 });
-        })
+            })
+        });
     });
-});
 </script>
 {% endblock %}


### PR DESCRIPTION
Add support for visualizing datasplits. Creates a neuroglancer link in the config drop down menu.
Add support for visualizing snapshots/validation volumes of a run. Creates a neuroglancer link and makes the run name clickable in run table.
Need to use the most recent dacapo/top-level-refactor branch since it adds support for generating neuroglancer layers for zarr arrays.
Some issues still remain (mostly backend problems but I wanted to list them here in case you run into them and or know of good solutions):
1) not all volumes can be visualized.
  - Only works on zarrs/n5s with specific metadata. For example jrc-mus-liver.n5/volumes/raw seems to work properly, but not the kidney version. Meta data seems to be stored slightly differently on those 2.
  - Doesn't work on volumes if the channel axes is split into chunks. Neuroglancer doesn't like this for some reason. (This is currently most of the validation volumes/snapshot volumes generated)
2) Somewhat awkward info displayed in the settings for zarr volumes. Since there isn't good support for reading zarr metadata I loaded all of the required voxel_size/offset data into the transform matrix. This left some awkward values in the transform table (1e-9)
3) Some wierdness around n5/zarr row/column ordering. Spatial axes of zarr volumes get transposed.
4) Seems to be pretty slow on volumes that aren't scale pyramids. I.e. snapshots and validation volumes.